### PR TITLE
StopIteration and str object TypeError bug fix

### DIFF
--- a/csvinsight/cli.py
+++ b/csvinsight/cli.py
@@ -123,7 +123,9 @@ def main(stdout=sys.stdout):
             _override_config(fin, args)
 
     if _is_tiny(args.path):
-        header, histogram, results = _run_in_memory(args.path, args)
+        with open(args.path) as fin:
+            reader = _open_csv(fin, args.delimiter)
+            header, histogram, results = _run_in_memory(reader, args)
     else:
         header = _read_header(args.path, args.delimiter)
         part_paths = _split_large_file(args.path)

--- a/csvinsight/split.py
+++ b/csvinsight/split.py
@@ -192,7 +192,7 @@ def split_in_memory(reader, list_columns=[], list_separator=LIST_SEPARATOR):
     try:
         header = next(reader)
     except StopIteration:
-        raise ValueError('Header may not be None')
+        raise ValueError('Reader may not be empty')
     histogram = collections.Counter()
     columns = [[] for _ in header]
     for i, row in enumerate(reader, 1):

--- a/csvinsight/split.py
+++ b/csvinsight/split.py
@@ -188,7 +188,11 @@ def split_in_memory(reader, list_columns=[], list_separator=LIST_SEPARATOR):
     if six.PY2:
         list_columns = [six.binary_type(col) for col in list_columns]
         list_separator = six.binary_type(list_separator)
-    header = next(reader)
+
+    try:
+        header = next(reader)
+    except StopIteration:
+        raise ValueError('Header may not be None')
     histogram = collections.Counter()
     columns = [[] for _ in header]
     for i, row in enumerate(reader, 1):

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 import collections
 import io
 
+import pytest
 import six
 import six.moves.queue as Queue
 
@@ -57,6 +58,11 @@ def test_run_in_memory():
     assert header == (b'foo', b'bar', b'baz')
     assert histogram == collections.Counter([3, 3, 2])
     assert columns == [[b'1', b'0'], [b'2', b'a', b'b'], [b'3', b'']]
+
+
+def test_read_empty_file():
+    with pytest.raises(ValueError):
+        csvinsight.split.split_in_memory(iter([]))
 
 
 def test_populate_queues():


### PR DESCRIPTION
csvinsight/split.py: line 191, fixed "StopIteration" error at `header = next(reader)` with try-except

csvinsight/cli.py: line 125, fixed "TypeError: str object is not an iterator" at `if _is_tiny(args.path)`

tests/test_split.py: line 63, added `test_read_empty_file()`.